### PR TITLE
Authorization using moodle cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-[![Build Status](https://img.shields.io/github/workflow/status/simonschiller/tutorbot/CI)](https://github.com/simonschiller/tutorbot/actions) 
+[![Build Status](https://img.shields.io/github/workflow/status/simonschiller/tutorbot/CI)](https://github.com/simonschiller/tutorbot/actions)
 [![GitHub Release](https://img.shields.io/github/v/release/simonschiller/tutorbot)](https://github.com/simonschiller/tutorbot/releases)
 [![License](https://img.shields.io/github/license/simonschiller/tutorbot)](https://github.com/simonschiller/tutorbot/blob/master/LICENSE)
 
 # Tutorbot
 
-Tutorbot is a simple command line tool that helps programming tutors at the University of Applied Sciences in Hagenberg by automating repetitive tasks. 
+Tutorbot is a simple command line tool that helps programming tutors at the University of Applied Sciences in Hagenberg
+by automating repetitive tasks.
 
 ### Features
 
@@ -13,11 +14,12 @@ Tutorbot comes with a range of different features, it can support you by:
 * downloading (and extracting) all submissions for a certain exercise
 * checking submissions for plagiarism
 * downloading all reviews for a certain exercise
-* sending feedback emails to students 
+* sending feedback emails to students
 
 ### Configuration
 
-Tutorbot requires different user inputs, some of them are likely repetitive. To avoid repeating them every time, these inputs can be stored in a configuration file. Currently the configuration file supports the following values:
+Tutorbot requires different user inputs, some of them are likely repetitive. To avoid repeating them every time, these
+inputs can be stored in a configuration file. Currently the configuration file supports the following values:
 
 ```properties
 # Moodle username (only works for local accounts since mandatory 2FA)
@@ -28,73 +30,89 @@ moodle.url=https://elearning.fh-ooe.at/
 # Uncomment to authorize with the MoodleSessionlmsfhooe cookie 
 # Instead of local username and password
 # moodle.auth.method=cookie 
-
 # Email address and username of person who sends feedback emails
 email.address=sXXXXXXXXXX@fhooe.at
 email.username=sXXXXXXXXXX
 email.password=XXXXXX
-
 # <students-id>@<email.students.suffix> => for receivers of emails
 email.students.suffix=fhooe.at
-
 # Base directory where exercise folders will be stored
-location.basedir = ../
-
+location.basedir=../
 # Subdirectory for current exercise
 # it's better to not set this property, you do not want to edit the config whenever you download something
 # just type it when the command asks you
 # location.exercise.subdir = e1
-
 # Subdirectory where submissions and reviews will be stored
-location.submissions.subdir = submissions
-location.reviews.subdir = reviews
-
+location.submissions.subdir=submissions
+location.reviews.subdir=reviews
 # This current setup directory would be like this would look like this
 # ./basedir/exercise.subdir/submissions
 # ./basedir/exercise.subdir/reviews
 # The exercise.subdir would be replaced by whatever target dir you put into the command when it asks you
-
 # Java language version used by JPlag for plagiarism detection (default is Java 1.9)
 # remove / comment line below for java
 plagiarism.language.java.version=c/c++
-
 # Templates for Email use %s for template parameters, Umlaute i.e ü, ö, ä are not supported by the encoding
 email.template.subject=Feedback zur Uebung %s
 email.template.body=Hallo,\n\nanbei euer Feedback zur Uebung %s.\nBei Fragen koennt ihr mir gerne auf diese E-Mail antworten.\n\nLG\n XXX.
 ```
 
-For Tutorbot to detect this file, it should be located in the same directory as the `tutorbot.jar` and should be called `tutorbot.properties`. It is also possible to configure those parameters using environment variables:
+For Tutorbot to detect this file, it should be located in the same directory as the `tutorbot.jar` and should be
+called `tutorbot.properties`. It is also possible to configure those parameters using environment variables:
 
-| Environment variable                        | Description                                                                                            |
-|---------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `TUTORBOT_MOODLE_USERNAME`                  | Moodle username (only works for local accounts since mandatory 2FA)                                    |
-| `TUTORBOT_MOODLE_PASSWORD`                  | Moodle password                                                                                        |
-| `TUTORBOT_MOODLE_URL`                       | Moodle base url (default https://elearning.fh-ooe.at/)                                                 |
-| `TUTORBOT_EMAIL_ADDRESS`                    | E-Mail address the feedback will be sent from                                                          |
-| `TUTORBOT_EMAIL_USERNAME`                   | Username for the E-Mail service                                                                        |
-| `TUTORBOT_EMAIL_PASSWORD`                   | Password for the E-Mail service                                                                        |
-| `TUTORBOT_EMAIL_TEMPLATE_SUBJECT`           | Template string for the subject of E-Mails sent to students. %s is used as placeholder.                |
-| `TUTORBOT_EMAIL_TEMPLATE_BODY`              | Template string for the body of E-Mails sent to students. %s is used as placeholder.                   |
-| `TUTORBOT_EMAIL_STUDENTS_SUFFIX`            | Suffix of E-Mail addresses of students (default fhooe.at)                                              |
-| `TUTORBOT_LOCATION_BASEDIR`                 | Base-location where Tutorbot will create other folders                                                 |
-| `TUTORBOT_LOCATION_EXERCISE_SUBDIR`         | Subfolder of basedir for the exercise                                                                  |
-| `TUTORBOT_LOCATION_SUBMISSIONS_SUBDIR`      | Subfolder of exercise as download location for submissions                                             |
-| `TUTORBOT_LOCATION_REVIEWS_SUBDIR`          | Subfolder of exercise as download location for reviews                                                 |
-| `TUTORBOT_PLAGIARISM_LANGUAGE_JAVA_VERSION` | Java language version used by JPlag for plagiarism detection (default is Java 1.9). Also supports C/C++. |
+| Environment variable                        | Description                                                                                                                            |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `TUTORBOT_MOODLE_USERNAME`                  | Moodle username (only works for local accounts since mandatory 2FA)                                                                    |
+| `TUTORBOT_MOODLE_PASSWORD`                  | Moodle password                                                                                                                        |
+| `TUTORBOT_MOODLE_URL`                       | Moodle base url (default https://elearning.fh-ooe.at/)                                                                                 |
+| `TUTORBOT_MOODLE_AUTH_METHOD`               | Moodle authorization method used for downloading. Can optionally be set to "cookie". Default authorization uses username and password. |
+| `TUTORBOT_EMAIL_ADDRESS`                    | E-Mail address the feedback will be sent from                                                                                          |
+| `TUTORBOT_EMAIL_USERNAME`                   | Username for the E-Mail service                                                                                                        |
+| `TUTORBOT_EMAIL_PASSWORD`                   | Password for the E-Mail service                                                                                                        |
+| `TUTORBOT_EMAIL_TEMPLATE_SUBJECT`           | Template string for the subject of E-Mails sent to students. %s is used as placeholder.                                                |
+| `TUTORBOT_EMAIL_TEMPLATE_BODY`              | Template string for the body of E-Mails sent to students. %s is used as placeholder.                                                   |
+| `TUTORBOT_EMAIL_STUDENTS_SUFFIX`            | Suffix of E-Mail addresses of students (default fhooe.at)                                                                              |
+| `TUTORBOT_LOCATION_BASEDIR`                 | Base-location where Tutorbot will create other folders                                                                                 |
+| `TUTORBOT_LOCATION_EXERCISE_SUBDIR`         | Subfolder of basedir for the exercise                                                                                                  |
+| `TUTORBOT_LOCATION_SUBMISSIONS_SUBDIR`      | Subfolder of exercise as download location for submissions                                                                             |
+| `TUTORBOT_LOCATION_REVIEWS_SUBDIR`          | Subfolder of exercise as download location for reviews                                                                                 |
+| `TUTORBOT_PLAGIARISM_LANGUAGE_JAVA_VERSION` | Java language version used by JPlag for plagiarism detection (default is Java 1.9). Also supports C/C++.                               |
 
-Values from the properties file will take precedence over values from environment variables if both are specified. 
+Values from the properties file will take precedence over values from environment variables if both are specified.
 
 ### Using the tutorbot
 
 The folder "tutorbot" contains everything needed to run the cli tool.
 
-On Windows use the powershell script `tutorbot.ps1` followed by the command you want to execute. The following image show how to execute the `reviews` command. This uses the default `tutotrbot.properties` and creates the folder `../vz/exercise-01/reviews` containing the downloaded reviews and `../vz/exercise-01/submissions` containing the submission + the result of the plagiarism check.
+On Windows use the powershell script `tutorbot.ps1` followed by the command you want to execute. The following image
+show how to execute the `reviews` command. This uses the default `tutotrbot.properties` and creates the
+folder `../vz/exercise-01/reviews` containing the downloaded reviews and `../vz/exercise-01/submissions` containing the
+submission + the result of the plagiarism check.
 
 ![img.png](images/review-example.png)
 
-If you are getting weird characters in your console, your terminal probably does not have support for ANSI Color Codes enabled. If you are on Windows, this can be fixed by using the `Windows Terminal` app or by using the `tutorbotWithoutWT.ps1` script (instead of `tutorbot.ps1`) which opens a powershell session with ANSI color codes enabled.
- 
+If you are getting weird characters in your console, your terminal probably does not have support for ANSI Color Codes
+enabled. If you are on Windows, this can be fixed by using the `Windows Terminal` app or by using
+the `tutorbotWithoutWT.ps1` script (instead of `tutorbot.ps1`) which opens a powershell session with ANSI color codes
+enabled.
+
+#### Authorization with cookie
+Since moodle has a strict OIDC authorization for students' accounts, a simple login with username and password is not possible anymore. 
+Current workarounds include:
+* Using a local moodle account, which is added to the courses.
+* Authorizing with a student account using a copied cookie from a browser.
+
+To perform the latter a few steps have to be taken:
+* Enabling `moodle.auth.method=cookie` in the properties.
+* Logging in moodle using any browser.
+* Copying the value of the `MoodleSessionlmsfhooe` Cookie after successful login.
+
+After this, any download command of tutorbot can be performed using the cookie value. If this did not work,
+check if the cookie value changed after a browser refresh.
 
 ### Buildling this project
 
-Tutorbot is built using Gradle. You don't need to install anything, as the Gradle wrapper is included in the repository. To build the project, simply execute `./gradlew jar`, the resulting JAR file will be located under `/build/libs/tutorbot.jar`. Please note that a JDK with version 11 or higher is required to build and run this tool, this limitation comes from JPlag. 
+Tutorbot is built using Gradle. You don't need to install anything, as the Gradle wrapper is included in the repository.
+To build the project, simply execute `./gradlew jar`, the resulting JAR file will be located
+under `/build/libs/tutorbot.jar`. Please note that a JDK with version 11 or higher is required to build and run this
+tool, this limitation comes from JPlag. 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ moodle.username=ha20210005
 # Set the password for ease of use
 moodle.password=XXXXXX
 moodle.url=https://elearning.fh-ooe.at/
+# Uncomment to authorize with the MoodleSessionlmsfhooe cookie 
+# Instead of local username and password
+# moodle.auth.method=cookie 
 
 # Email address and username of person who sends feedback emails
 email.address=sXXXXXXXXXX@fhooe.at

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/auth/CredentialStore.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/auth/CredentialStore.kt
@@ -10,6 +10,7 @@ import javax.inject.Singleton
 class CredentialStore @Inject constructor(configHandler: ConfigHandler) {
     private var moodleUsername: String? = null
     private var moodlePassword: String? = null
+    private var moodleCookie: String? = null
     private var emailAddress: String? = null
     private var emailUsername: String? = null
     private var emailPassword: String? = null
@@ -38,6 +39,10 @@ class CredentialStore @Inject constructor(configHandler: ConfigHandler) {
     fun getMoodlePassword(): String {
         // return moodlePassword ?: promptTextInput("Enter moodle password ($moodleUsername):").also { moodlePassword = it }
         return moodlePassword ?: promptPasswordInput("Enter moodle password ($moodleUsername):").also { moodlePassword = it }
+    }
+
+    fun getMoodleCookie(): String {
+        return moodleCookie ?: promptTextInput("Enter authorization cookie value (MoodleSessionlmsfhooe):").also { moodleCookie = it }
     }
 
     fun getEmailPassword(): String {

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/auth/CredentialStore.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/auth/CredentialStore.kt
@@ -42,7 +42,8 @@ class CredentialStore @Inject constructor(configHandler: ConfigHandler) {
     }
 
     fun getMoodleCookie(): String {
-        return moodleCookie ?: promptTextInput("Enter authorization cookie value (MoodleSessionlmsfhooe):").also { moodleCookie = it }
+        return moodleCookie
+            ?: promptTextInput("Enter authorization cookie value ($COOKIE_AUTH_NAME):").also { moodleCookie = it }
     }
 
     fun getEmailPassword(): String {
@@ -52,5 +53,9 @@ class CredentialStore @Inject constructor(configHandler: ConfigHandler) {
 
     fun setEmailPassword(value: String?) {
         emailPassword = value;
+    }
+
+    companion object {
+        const val COOKIE_AUTH_NAME = "MoodleSessionlmsfhooe"
     }
 }

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/auth/MoodleAuthenticator.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/auth/MoodleAuthenticator.kt
@@ -3,7 +3,6 @@ package at.fhooe.hagenberg.tutorbot.auth
 import at.fhooe.hagenberg.tutorbot.components.ConfigHandler
 import at.fhooe.hagenberg.tutorbot.util.exitWithError
 import at.fhooe.hagenberg.tutorbot.util.printlnGreen
-import at.fhooe.hagenberg.tutorbot.util.printlnRed
 import at.fhooe.hagenberg.tutorbot.util.value
 import okhttp3.*
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -78,7 +77,7 @@ class MoodleAuthenticator @Inject constructor(
         return Cookie.Builder()
             .hostOnlyDomain(domain)
             .path("/")
-            .name(COOKIE_AUTH_NAME)
+            .name(CredentialStore.COOKIE_AUTH_NAME)
             .value(value)
             .secure()
             .build()
@@ -97,6 +96,5 @@ class MoodleAuthenticator @Inject constructor(
 
     private companion object {
         const val MOODLE_LOGIN_URL = "login/index.php"
-        const val COOKIE_AUTH_NAME = "MoodleSessionlmsfhooe"
     }
 }

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/auth/MoodleAuthenticator.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/auth/MoodleAuthenticator.kt
@@ -66,13 +66,14 @@ class MoodleAuthenticator @Inject constructor(
             listOf(createMoodleCookie(credentialStore.getMoodleCookie()))
         )
 
-        val homeUrl = configHandler.getMoodleUrl() + MOODLE_HOME_URL
+        // Test request will be redirected to /login if cookie is invalid
+        val homeUrl = configHandler.getMoodleUrl()
         val request = Request.Builder().url(homeUrl).build()
         return http.newCall(request).execute()
     }
 
     private fun createMoodleCookie(value: String): Cookie {
-        // Domain has to exclude www., use moddle url as input
+        // Domain has to exclude www., use moodle url as input
         val domain = URI(configHandler.getMoodleUrl()).host.split("www.").last()
         return Cookie.Builder()
             .hostOnlyDomain(domain)
@@ -96,7 +97,6 @@ class MoodleAuthenticator @Inject constructor(
 
     private companion object {
         const val MOODLE_LOGIN_URL = "login/index.php"
-        const val MOODLE_HOME_URL = "my/" // Link to homepage
         const val COOKIE_AUTH_NAME = "MoodleSessionlmsfhooe"
     }
 }

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/components/ConfigHandler.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/components/ConfigHandler.kt
@@ -11,10 +11,13 @@ class ConfigHandler @Inject constructor(@Named("config") config: File) {
     private val properties by lazy { parseProperties(config) }
 
     private var exerciseDirectory: String? = null
+    enum class AuthMethod { USER_PASS, COOKIE }
+
 
     fun getMoodleUsername(): String? = getProperty("moodle.username")
     fun getMoodlePassword(): String? = getProperty("moodle.password")
     fun getMoodleUrl(): String = getProperty("moodle.url") ?: "https://elearning.fh-ooe.at/"
+    fun getMoodleAuthMethod(): AuthMethod = if (getProperty("moodle.auth.method")?.toLowerCase() == "cookie") AuthMethod.COOKIE else AuthMethod.USER_PASS
 
     fun getEmailAddress(): String? = getProperty("email.address")
     fun getEmailUsername(): String? = getProperty("email.username")

--- a/src/main/resources/tutorbot.properties
+++ b/src/main/resources/tutorbot.properties
@@ -3,6 +3,7 @@ moodle.username=ha20210005
 # Set the password for ease of use
 moodle.password=XXXXXX
 moodle.url=https://elearning.fh-ooe.at/
+moodle.auth.method=COOKIE
 
 # Email address and username of person who sends feedback emails
 email.address=sXXXXXXXXXX@fhooe.at

--- a/src/main/resources/tutorbot.properties
+++ b/src/main/resources/tutorbot.properties
@@ -3,7 +3,9 @@ moodle.username=ha20210005
 # Set the password for ease of use
 moodle.password=XXXXXX
 moodle.url=https://elearning.fh-ooe.at/
-moodle.auth.method=COOKIE
+# Uncomment to authorize with the MoodleSessionlmsfhooe cookie
+# Instead of local username and password
+# moodle.auth.method=cookie
 
 # Email address and username of person who sends feedback emails
 email.address=sXXXXXXXXXX@fhooe.at

--- a/src/test/kotlin/at/fhooe/hagenberg/tutorbot/components/ConfigHandlerTest.kt
+++ b/src/test/kotlin/at/fhooe/hagenberg/tutorbot/components/ConfigHandlerTest.kt
@@ -20,6 +20,7 @@ class ConfigHandlerTest {
         assertEquals("config-moodle-username", configHandler.getMoodleUsername())
         assertEquals("config-moodle-password", configHandler.getMoodlePassword())
         assertEquals("config-moodle-url", configHandler.getMoodleUrl())
+        assertEquals(ConfigHandler.AuthMethod.COOKIE, configHandler.getMoodleAuthMethod())
         assertEquals("config-email-address", configHandler.getEmailAddress())
         assertEquals("config-email-username", configHandler.getEmailUsername())
         assertEquals("config-email-password", configHandler.getEmailPassword())
@@ -64,6 +65,14 @@ class ConfigHandlerTest {
         assertEquals("config-username", configHandler.getMoodleUsername())
         assertNull(configHandler.getBaseDir())
         assertNull(configHandler.getJavaLanguageLevel())
+    }
+
+    @Test
+    fun `Moodle authorization config defaults to USER_PASS when not present`() {
+        val config = File(ClassLoader.getSystemResource("config/missing.properties").toURI())
+        val configHandler = ConfigHandler(config)
+
+        assertEquals(ConfigHandler.AuthMethod.USER_PASS, configHandler.getMoodleAuthMethod())
     }
 
     @Test

--- a/src/test/resources/config/all.properties
+++ b/src/test/resources/config/all.properties
@@ -1,6 +1,7 @@
 moodle.username=config-moodle-username
 moodle.password=config-moodle-password
 moodle.url=config-moodle-url
+moodle.auth.method=cookie
 
 email.address=config-email-address
 email.username=config-email-username


### PR DESCRIPTION
Since OIDC authorization was implemented, students have not been able to use their own account in tutorbot.  To allow downloading using students' accounts again, a login method using the `MoodleSessionlmsfhooe` cookie was implemented.

This workaround was chosen because:
* It works with any browser.
* It does not need a new dependency, browser installation.
* It is sufficient at the moment, as local accounts still work well for authorization.

But as this solution may not be optimal, in the future it might be possible to:
* Include a web-browser in the project, where authorization will be performed and the cookie will be read from.
* Implement a command line version of the Office365 authorization process

