### PR TITLE
jPlag parser logs, plagiarism folder moved, ChooseFeedbackCommand refactored

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ https://github.com/jheinzel/tutorbot/releases
 
 Tutorbot comes with a range of different features, it can support you by:
 
+* downloading all reviews for a certain exercise
 * downloading (and extracting) all submissions for a certain exercise
 * checking submissions for plagiarism
-* downloading all reviews for a certain exercise
+* choosing reviews to give feedback on based on the amount of feedbacks a student has received
 * sending feedback emails to students
-* choosing reviews to give feedback to
-* saving amount of feedbacks each student has received
 
 ## Configuration
 
@@ -137,6 +136,7 @@ under `/build/libs/tutorbot.jar`. Please note that a JDK with version 11 or high
 tool, this limitation comes from JPlag. 
 
 ## Releasing a new version
+First the version in the `build.gradle.kts` has to be updated. Then the following steps have to be performed:
 Before releasing, check if your changes are merged in the main branch.  
 To release a new version, create and push a `tag` on the main branch with a name like `v*.*`. 
 This can be done with the following commands:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "at.fhooe.hagenberg"
-version = "1.4.0"
+version = "1.4.1"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/ChooseFeedbackCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/ChooseFeedbackCommand.kt
@@ -21,7 +21,8 @@ import javax.inject.Inject
 class ChooseFeedbackCommand @Inject constructor(
     private val configHandler: ConfigHandler,
     private val feedbackFileHelper: FeedbackFileHelper,
-    private val feedbackChooseLogic: FeedbackChooseLogic
+    private val feedbackChooseLogic: FeedbackChooseLogic,
+    private val saveFeedbackCommand: SaveFeedbackCommand
 ) : BaseCommand() {
     override fun execute() {
         // Current ex. reviews path
@@ -60,8 +61,13 @@ class ChooseFeedbackCommand @Inject constructor(
             printlnGreen("Picked $feedbackCount reviews.")
 
         moveReviews(sourceDirectory, reviewsToMove)
-
         printlnGreen("Finished selecting reviews to feedback.")
+
+        if (promptBooleanInput("Save current feedback selection?")) {
+            saveFeedbackCommand.execute()
+        } else {
+            printlnCyan("Feedback selection was not saved. Please save your selection with save-feedback when you are done.")
+        }
     }
 
     private fun moveReviews(

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/ChooseFeedbackCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/ChooseFeedbackCommand.kt
@@ -1,19 +1,18 @@
 package at.fhooe.hagenberg.tutorbot.commands
 
 import at.fhooe.hagenberg.tutorbot.components.ConfigHandler
-import at.fhooe.hagenberg.tutorbot.components.FeedbackHelper
-import at.fhooe.hagenberg.tutorbot.components.FeedbackHelper.FeedbackCount
-import at.fhooe.hagenberg.tutorbot.components.FeedbackHelper.Review
+import at.fhooe.hagenberg.tutorbot.components.FeedbackChooseLogic
+import at.fhooe.hagenberg.tutorbot.components.FeedbackFileHelper
+import at.fhooe.hagenberg.tutorbot.domain.FeedbackCount
+import at.fhooe.hagenberg.tutorbot.domain.Review
 import at.fhooe.hagenberg.tutorbot.util.exitWithError
 import at.fhooe.hagenberg.tutorbot.util.printlnCyan
 import at.fhooe.hagenberg.tutorbot.util.printlnGreen
 import at.fhooe.hagenberg.tutorbot.util.promptBooleanInput
 import picocli.CommandLine.Command
-import java.io.File
 import java.io.FileNotFoundException
 import java.nio.file.Path
 import javax.inject.Inject
-import kotlin.random.Random
 
 @Command(
     name = "choose-feedback",
@@ -21,106 +20,16 @@ import kotlin.random.Random
 )
 class ChooseFeedbackCommand @Inject constructor(
     private val configHandler: ConfigHandler,
-    private val feedbackHelper: FeedbackHelper,
-    private val random: Random
+    private val feedbackFileHelper: FeedbackFileHelper,
+    private val feedbackChooseLogic: FeedbackChooseLogic
 ) : BaseCommand() {
-    /**
-     * Adds the review to the chosenReviews if both participating students are not in the chosenReviews already.
-     * @return true if added
-     */
-    private fun addIfAllowed(review: Review, chosenReviews: MutableCollection<Review>): Boolean =
-        if (chosenReviews.none { r ->
-                r.subStudentNr == review.revStudentNr || r.subStudentNr == review.subStudentNr
-                        || r.revStudentNr == review.revStudentNr || r.revStudentNr == review.subStudentNr
-            }) chosenReviews.add(review) else false
-
-    /**
-     * Tries to pop a Review from the reviews, which either has the student as submitter or reviewer.
-     * @return Review if present in reviews
-     */
-    private fun tryPopReviewForStudent(
-        student: String,
-        reviews: MutableCollection<Review>,
-        asSubmitter: Boolean
-    ): Review? =
-        when (asSubmitter) {
-            true -> reviews.firstOrNull { r -> r.subStudentNr == student }
-            false -> reviews.firstOrNull { r -> r.revStudentNr == student }
-        }?.also { reviews.remove(it) }
-
-    /**
-     * Chooses reviews to be selected for feedback. Students who have gotten the least feedbacks on submissions and reviews are preferred.
-     * Random reviews regardless of their received feedback amount may also be chosen if defined (useful to avoid predictability).
-     */
-    private fun pickReviewsToFeedback(
-        reviews: MutableSet<Review>,
-        feedbackCsv: File,
-        feedbackCount: Int,
-        randomCount: Int
-    ): Set<Review> {
-        val feedbackCountMap = try {
-            feedbackHelper.readFeedbackCountFromCsv(feedbackCsv)
-        } catch (e: FileNotFoundException) {
-            mapOf<String, FeedbackCount>() // If file does not exist, just return empty map
-        } catch (e: Exception) {
-            exitWithError(e.message ?: "Parsing feedback CSV failed.")
-        }
-        val chosenReviews = mutableSetOf<Review>()
-        val canStillPickReviews = { reviews.isNotEmpty() && chosenReviews.size < feedbackCount }
-
-        // 1) Chose random reviews first
-        while (canStillPickReviews() && chosenReviews.size < randomCount) {
-            val review = reviews.random(random).also { reviews.remove(it) }
-            addIfAllowed(review, chosenReviews)
-        }
-
-        if (!canStillPickReviews()) return chosenReviews
-
-        // 2) Choose students who have not gotten any feedback, does not matter if feedback on submission or review
-        val studentsWithNoFeedback = reviews
-            .flatMap { r -> listOf(r.subStudentNr, r.revStudentNr) }
-            .distinct()
-            .filter { s -> s !in feedbackCountMap }
-            .shuffled(random)
-            .toMutableList()
-        while (canStillPickReviews() && studentsWithNoFeedback.isNotEmpty()) {
-            val student = studentsWithNoFeedback.first()
-            studentsWithNoFeedback.remove(student)
-            tryPopReviewForStudent(student, reviews, true)?.also {
-                addIfAllowed(it, chosenReviews)
-            }
-        }
-
-        if (!canStillPickReviews()) return chosenReviews
-
-        // 3) Choose students by ordering amount of feedback received
-        val feedbackOrdering = feedbackCountMap
-            .toList()
-            .filter { pair -> pair.first in reviews.flatMap { r -> listOf(r.subStudentNr, r.revStudentNr) } }
-            .shuffled(random)
-            .sortedBy { pair -> pair.second }
-            .toMutableList()
-        while (canStillPickReviews() && feedbackOrdering.isNotEmpty()) {
-            val picked = feedbackOrdering.first()
-            feedbackOrdering.remove(picked)
-
-            // Try to keep amount of feedbacks on submissions and reviews the same
-            val shouldPickSubmission = picked.second.submission <= picked.second.review
-            tryPopReviewForStudent(picked.first, reviews, shouldPickSubmission)?.also {
-                addIfAllowed(it, chosenReviews)
-            }
-        }
-
-        return chosenReviews
-    }
-
     override fun execute() {
         // Current ex. reviews path
         val baseDir = configHandler.getBaseDir()
         val exerciseSubDir = configHandler.getExerciseSubDir()
         val reviewsDir = configHandler.getReviewsSubDir()
         val sourceDirectory = Path.of(baseDir, exerciseSubDir, reviewsDir)
-        val reviews = feedbackHelper.readAllReviewsFromDir(sourceDirectory.toFile())
+        val reviews = feedbackFileHelper.readAllReviewsFromDir(sourceDirectory.toFile())
         if (reviews.isEmpty()) exitWithError("Reviews folder does not contain any valid files!")
 
         // Get CSV with count of previous feedbacks
@@ -134,8 +43,15 @@ class ChooseFeedbackCommand @Inject constructor(
         if (randomCount < 0 || randomCount > feedbackCount) exitWithError("Random feedback count must be >= 0 and <= feedback count.")
 
         // Pick reviews
+        val feedbackCountMap = try {
+            feedbackFileHelper.readFeedbackCountFromCsv(feedbackCsv)
+        } catch (e: FileNotFoundException) {
+            mapOf<String, FeedbackCount>() // If file does not exist, just return empty map
+        } catch (e: Exception) {
+            exitWithError(e.message ?: "Parsing feedback CSV failed.")
+        }
         val reviewsToFeedback =
-            pickReviewsToFeedback(reviews.toMutableSet(), feedbackCsv, feedbackCount, randomCount)
+            feedbackChooseLogic.pickReviewsToFeedback(feedbackCountMap, reviews, feedbackCount, randomCount)
         val reviewsToMove = reviews - reviewsToFeedback
 
         if (reviewsToFeedback.size != feedbackCount)
@@ -143,6 +59,15 @@ class ChooseFeedbackCommand @Inject constructor(
         else
             printlnGreen("Picked $feedbackCount reviews.")
 
+        moveReviews(sourceDirectory, reviewsToMove)
+
+        printlnGreen("Finished selecting reviews to feedback.")
+    }
+
+    private fun moveReviews(
+        sourceDirectory: Path,
+        reviewsToMove: Set<Review>
+    ) {
         val targetDirectory = sourceDirectory.resolve(NOT_SELECTED_DIR)
         if (!targetDirectory.toFile().mkdir()) {
             if (!promptBooleanInput("Target location $targetDirectory already exists, should its contents be overwritten?")) {
@@ -161,8 +86,6 @@ class ChooseFeedbackCommand @Inject constructor(
                 exitWithError(ex.message ?: "Moving ${rev.fileName} failed.")
             }
         }
-
-        printlnGreen("Finished selecting reviews to feedback.")
     }
 
     companion object {

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/InstructionsCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/InstructionsCommand.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 @Command(
     name = "instructions",
-    description = ["Prints out general instructions on which steps need to be done by the tutor"]
+    description = ["Prints out general instructions on which steps need to be done by the tutor."]
 )
 class InstructionsCommand @Inject constructor() : BaseCommand() {
 
@@ -16,10 +16,10 @@ class InstructionsCommand @Inject constructor() : BaseCommand() {
         println("- Check the plagiarism report (index.html) and if there are errors parser.log will have more information.")
         println("- Select reviews randomly by using the choose-feedback command or manually making sure everybody gets chosen fairly.")
         println("- If you have not done it already in the choose-feedback command, save the feedback count using the save-feedback command. This data will be used for choosing reviews next time.")
+        println("- Enter which students you are going to review in the excel sheet.")
         println("- Add your feedback to the selected reviews.")
         println("- Collect general feedback and common mistakes for this homework and write it in a markdown file.")
         println("- Send emails to students with the reviewed PDFs (use the mail command).")
-        println("- Upload all reviewed PDfs as well as the markdown file to the file share.")
-        println("- Enter which students you reviewed in the excel sheet.")
+        println("- Upload all reviewed PDFs as well as the markdown file to the file share.")
     }
 }

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/InstructionsCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/InstructionsCommand.kt
@@ -13,6 +13,7 @@ class InstructionsCommand @Inject constructor() : BaseCommand() {
         println("To review a homework, the following steps need to be taken:")
         println("- Download all the reviews (use the reviews command). May also download submissions to skip the next step.")
         println("- Download all the submissions and check for plagiarism (use the download submissions command).")
+        println("- Check the plagiarism report (index.html) and if there are errors parser.log will have more information.")
         println("- Select reviews randomly by using the choose-feedback command or manually making sure everybody gets chosen fairly.")
         println("- If you have not done it already in the choose-feedback command, save the feedback count using the save-feedback command. This data will be used for choosing reviews next time.")
         println("- Add your feedback to the selected reviews.")

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/InstructionsCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/InstructionsCommand.kt
@@ -11,13 +11,13 @@ class InstructionsCommand @Inject constructor() : BaseCommand() {
 
     override fun execute() {
         println("To review a homework, the following steps need to be taken:")
-        println("- Download all the reviews (use the reviews command). May also download submissions in this step if needed.")
+        println("- Download all the reviews (use the reviews command). May also download submissions to skip the next step.")
         println("- Download all the submissions and check for plagiarism (use the download submissions command).")
         println("- Select reviews randomly by using the choose-feedback command or manually making sure everybody gets chosen fairly.")
+        println("- If you have not done it already in the choose-feedback command, save the feedback count using the save-feedback command. This data will be used for choosing reviews next time.")
         println("- Add your feedback to the selected reviews.")
         println("- Collect general feedback and common mistakes for this homework and write it in a markdown file.")
-        println("- Send emails to students with the reviewed PDFs (use the mail command). May also save the feedback counts in this step.")
-        println("- (Do this only if it was not already done in the mail command!) Save the feedback amount using the save-feedback command. This data will be used for choosing reviews next time.")
+        println("- Send emails to students with the reviewed PDFs (use the mail command).")
         println("- Upload all reviewed PDfs as well as the markdown file to the file share.")
         println("- Enter which students you reviewed in the excel sheet.")
     }

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/MailCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/MailCommand.kt
@@ -16,7 +16,6 @@ import javax.mail.AuthenticationFailedException
 )
 class MailCommand @Inject constructor(
     private val mailClient: MailClient,
-    private val saveFeedbackCommand: SaveFeedbackCommand,
     private val credentialStore: CredentialStore,
     private val configHandler: ConfigHandler
 ) : BaseCommand() {
@@ -71,12 +70,6 @@ class MailCommand @Inject constructor(
                     printlnRed("failed (${exception::class.java.typeName}; ${exception.message})")
                 }
             }
-        }
-
-        // Prompt for feedback saving also
-        if (promptBooleanInput("Do you also want to save the feedbacks count to CSV?"))
-        {
-            saveFeedbackCommand.execute()
         }
     }
 

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/MailCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/MailCommand.kt
@@ -12,7 +12,7 @@ import javax.mail.AuthenticationFailedException
 
 @Command(
     name = "mail",
-    description = ["Sends PDFs containing the feedback via email"]
+    description = ["Sends PDFs containing the feedback via email."]
 )
 class MailCommand @Inject constructor(
     private val mailClient: MailClient,

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/PlagiarismCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/PlagiarismCommand.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 @Command(
     name = "plagiarism",
-    description = ["Checks downloaded submissions for plagiarism"]
+    description = ["Checks downloaded submissions for plagiarism."]
 )
 class PlagiarismCommand @Inject constructor(
     private val plagiarismChecker: PlagiarismChecker,

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/PlagiarismCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/PlagiarismCommand.kt
@@ -1,10 +1,11 @@
 package at.fhooe.hagenberg.tutorbot.commands
 
+import at.fhooe.hagenberg.tutorbot.components.ConfigHandler
 import at.fhooe.hagenberg.tutorbot.components.PlagiarismChecker
 import at.fhooe.hagenberg.tutorbot.util.exitWithError
-import at.fhooe.hagenberg.tutorbot.util.promptTextInput
 import picocli.CommandLine.Command
 import java.io.File
+import java.nio.file.Path
 import javax.inject.Inject
 
 @Command(
@@ -12,19 +13,24 @@ import javax.inject.Inject
     description = ["Checks downloaded submissions for plagiarism"]
 )
 class PlagiarismCommand @Inject constructor(
-    private val plagiarismChecker: PlagiarismChecker
+    private val plagiarismChecker: PlagiarismChecker,
+    private val configHandler: ConfigHandler
 ) : BaseCommand() {
 
     override fun execute() {
-        val submissionsPath = promptTextInput("Enter submissions location (leave empty for current directory):")
-        val submissionsDirectory = File(submissionsPath)
+        val baseDir = configHandler.getBaseDir()
+        val exerciseSubDir = configHandler.getExerciseSubDir()
+        val submissionsDir = configHandler.getSubmissionsSubDir()
+        // Target is exercise dir not submissions dir so it's easier to find the folder
+        val targetDirectory = File(baseDir, exerciseSubDir)
+        val submissionsDirectory = Path.of(baseDir, exerciseSubDir, submissionsDir).toFile()
 
         // Make sure the submissions directory exists
         if (!submissionsDirectory.isDirectory) {
-            exitWithError("Submissions directory $submissionsPath does not point to a valid directory.")
+            exitWithError("Submissions directory '${submissionsDirectory.absolutePath}' does not point to a valid directory.")
         }
 
         // Check the results for plagiarism
-        plagiarismChecker.generatePlagiarismReport(submissionsDirectory)
+        plagiarismChecker.generatePlagiarismReport(submissionsDirectory, targetDirectory)
     }
 }

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/ReviewsCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/ReviewsCommand.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 @Command(
     name = "reviews",
-    description = ["Downloads all reviews for a certain exercise"]
+    description = ["Downloads all reviews for a certain exercise optionally also downloading the submissions."]
 )
 class ReviewsCommand @Inject constructor(
     private val moodleClient: MoodleClient,

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/ReviewsCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/ReviewsCommand.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 @Command(
     name = "reviews",
-    description = ["Downloads all reviews for a certain exercise optionally also downloading the submissions."]
+    description = ["Downloads all reviews for a certain exercise. Optionally also downloads the submissions and performs a plagiarism check."]
 )
 class ReviewsCommand @Inject constructor(
     private val moodleClient: MoodleClient,

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/SaveFeedbackCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/SaveFeedbackCommand.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 @Command(
     name = "save-feedback",
-    description = ["Should only be run if the feedback count was not saved when choosing the feedbacks. Counts the feedbacks in an exercise folder and updates the feedback CSV file."]
+    description = ["Should only be run if the feedback count was not saved with choose-feedback. Counts the feedbacks in an exercise folder and updates the feedback CSV file."]
 )
 class SaveFeedbackCommand @Inject constructor(
     private val configHandler: ConfigHandler,

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/VersionCommand.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/commands/VersionCommand.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 @Command(
     name = "version",
-    description = ["Shows tutorbot version information"]
+    description = ["Shows tutorbot version information."]
 )
 class VersionCommand @Inject constructor() : BaseCommand() {
 

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/components/FeedbackChooseLogic.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/components/FeedbackChooseLogic.kt
@@ -1,0 +1,107 @@
+package at.fhooe.hagenberg.tutorbot.components
+
+import at.fhooe.hagenberg.tutorbot.domain.FeedbackCount
+import at.fhooe.hagenberg.tutorbot.domain.Review
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+/**
+ * Logic behind choosing feedback from a list of reviews.
+ * Criteria: The students with the least amount of feedback should be chosen.
+ * But no student should be chosen twice for the same exercise (as reviewer and submitter).
+ */
+@Singleton
+class FeedbackChooseLogic @Inject constructor(private val random: Random) {
+    /**
+     * Adds the review to the chosenReviews if both participating students are not in the chosenReviews already.
+     * @return true if added
+     */
+    private fun addIfAllowed(
+        review: Review,
+        chosenReviews: MutableCollection<Review>
+    ): Boolean =
+        if (chosenReviews.none { r ->
+                r.subStudentNr == review.revStudentNr || r.subStudentNr == review.subStudentNr
+                        || r.revStudentNr == review.revStudentNr || r.revStudentNr == review.subStudentNr
+            }) chosenReviews.add(review) else false
+
+    /**
+     * Tries to pop a Review from the reviews, which either has the student as submitter or reviewer.
+     * @return Review if present in reviews
+     */
+    private fun tryPopReviewForStudent(
+        student: String,
+        reviews: MutableCollection<Review>,
+        asSubmitter: Boolean
+    ): Review? =
+        when (asSubmitter) {
+            true -> reviews.firstOrNull { r -> r.subStudentNr == student }
+            false -> reviews.firstOrNull { r -> r.revStudentNr == student }
+        }?.also { reviews.remove(it) }
+
+    /**
+     * Chooses reviews to be selected for feedback. Students who have gotten the least feedbacks on submissions and reviews are preferred.
+     * Random reviews regardless of their received feedback amount may also be chosen if defined (useful to avoid predictability).
+     * @param feedbackCountMap number of feedbacks a student has received on submissions and reviews
+     * @param reviewsLeft reviews to choose from
+     * @param feedbackCount amount of reviews to choose
+     * @param randomCount amount of random reviews to choose with no regard to feedback count
+     * @return List of chosen reviews
+     */
+    fun pickReviewsToFeedback(
+        feedbackCountMap: Map<String, FeedbackCount>,
+        reviews: Set<Review>,
+        feedbackCount: Int,
+        randomCount: Int
+    ): Set<Review> {
+        val chosenReviews = mutableSetOf<Review>()
+        val reviewsLeft = reviews.toMutableSet()
+        val canStillPickReviews = { reviewsLeft.isNotEmpty() && chosenReviews.size < feedbackCount }
+
+        // 1) Chose random reviews first
+        while (canStillPickReviews() && chosenReviews.size < randomCount) {
+            val review = reviewsLeft.random(random).also { reviewsLeft.remove(it) }
+            addIfAllowed(review, chosenReviews)
+        }
+
+        if (!canStillPickReviews()) return chosenReviews
+
+        // 2) Choose students who have not gotten any feedback, does not matter if feedback on submission or review
+        val studentsWithNoFeedback = reviewsLeft
+            .flatMap { r -> listOf(r.subStudentNr, r.revStudentNr) }
+            .distinct()
+            .filter { s -> s !in feedbackCountMap }
+            .shuffled(random)
+            .toMutableList()
+        while (canStillPickReviews() && studentsWithNoFeedback.isNotEmpty()) {
+            val student = studentsWithNoFeedback.first()
+            studentsWithNoFeedback.remove(student)
+            tryPopReviewForStudent(student, reviewsLeft, true)?.also {
+                addIfAllowed(it, chosenReviews)
+            }
+        }
+
+        if (!canStillPickReviews()) return chosenReviews
+
+        // 3) Choose students by ordering amount of feedback received
+        val feedbackOrdering = feedbackCountMap
+            .toList()
+            .filter { pair -> pair.first in reviewsLeft.flatMap { r -> listOf(r.subStudentNr, r.revStudentNr) } }
+            .shuffled(random)
+            .sortedBy { pair -> pair.second }
+            .toMutableList()
+        while (canStillPickReviews() && feedbackOrdering.isNotEmpty()) {
+            val picked = feedbackOrdering.first()
+            feedbackOrdering.remove(picked)
+
+            // Try to keep amount of feedbacks on submissions and reviews the same
+            val shouldPickSubmission = picked.second.submission <= picked.second.review
+            tryPopReviewForStudent(picked.first, reviewsLeft, shouldPickSubmission)?.also {
+                addIfAllowed(it, chosenReviews)
+            }
+        }
+
+        return chosenReviews
+    }
+}

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/components/FeedbackFileHelper.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/components/FeedbackFileHelper.kt
@@ -1,22 +1,13 @@
 package at.fhooe.hagenberg.tutorbot.components
 
+import at.fhooe.hagenberg.tutorbot.domain.FeedbackCount
+import at.fhooe.hagenberg.tutorbot.domain.Review
 import java.io.File
 import javax.inject.Inject
+import javax.inject.Singleton
 
-class FeedbackHelper @Inject constructor() {
-    // Tracks amount of feedbacks a student has received on submissions and reviews. Ordered by submission first then review.
-    data class FeedbackCount(val submission: Int, val review: Int) : Comparable<FeedbackCount> {
-        override fun compareTo(other: FeedbackCount): Int {
-            return compareValuesBy(this, other, { it.submission }, { it.review })
-        }
-    }
-
-    // Represents a Review, which has a student who submitted the code and one who reviewed it.
-    data class Review(
-        val fileName: String,
-        val subStudentNr: String,
-        val revStudentNr: String
-    )
+@Singleton
+class FeedbackFileHelper @Inject constructor() {
 
     /**
      * Reads all review files from a directory matching with the STUDENT_NR_PATTERN ignoring other files.

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/components/PlagiarismChecker.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/components/PlagiarismChecker.kt
@@ -12,16 +12,31 @@ class PlagiarismChecker @Inject constructor(
     private val configHandler: ConfigHandler
 ) {
 
-    fun generatePlagiarismReport(submissionDirectory: File) {
+    fun generatePlagiarismReport(submissionDirectory: File, outputDirectory: File) {
         val language = detectSubmissionLanguage(submissionDirectory)
-        val reportDirectory = File(submissionDirectory, "plagiarism-report")
-        val args = arrayOf("-l", language, "-r", reportDirectory.absolutePath, "-s", submissionDirectory.absolutePath)
+        val reportDirectory = File(outputDirectory, REPORT_FOLDER)
+        reportDirectory.mkdirs()
+        val logFile = File(reportDirectory, LOG_FILE)
+
+        // With subdirs (-s) verbose parser logging (-vp) and output to log file (-o)
+        val args = arrayOf(
+            "-l",
+            language,
+            "-r",
+            reportDirectory.absolutePath,
+            "-vp",
+            "-o",
+            logFile.absolutePath,
+            "-s",
+            submissionDirectory.absolutePath
+        )
 
         // Capture output while running JPlag
         runWithCapturedOutput {
             jplagWrapper.run(args)
         }
-        val reportFilePath = File(reportDirectory, "index.html").absolutePath
+
+        val reportFilePath = File(reportDirectory, INDEX_FILE).absolutePath
         println("Plagiarism output generated, you can check it here: $reportFilePath")
     }
 
@@ -38,5 +53,11 @@ class PlagiarismChecker @Inject constructor(
         fun run(args: Array<String>) {
             Program(CommandLineOptions(args)).run()
         }
+    }
+
+    companion object {
+        const val REPORT_FOLDER = "plagiarism-report"
+        const val LOG_FILE = "parser.log"
+        const val INDEX_FILE = "index.html"
     }
 }

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/domain/FeedbackCount.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/domain/FeedbackCount.kt
@@ -1,0 +1,10 @@
+package at.fhooe.hagenberg.tutorbot.domain
+
+/**
+ * Tracks amount of feedbacks a student has received on submissions and reviews. Ordered by submission first then review.
+ */
+data class FeedbackCount(val submission: Int, val review: Int) : Comparable<FeedbackCount> {
+    override fun compareTo(other: FeedbackCount): Int {
+        return compareValuesBy(this, other, { it.submission }, { it.review })
+    }
+}

--- a/src/main/kotlin/at/fhooe/hagenberg/tutorbot/domain/Review.kt
+++ b/src/main/kotlin/at/fhooe/hagenberg/tutorbot/domain/Review.kt
@@ -1,0 +1,10 @@
+package at.fhooe.hagenberg.tutorbot.domain
+
+/**
+ *  Represents a Review, which has a student who submitted the code and one who reviewed it.
+ */
+data class Review(
+    val fileName: String,
+    val subStudentNr: String,
+    val revStudentNr: String
+)

--- a/src/test/kotlin/at/fhooe/hagenberg/tutorbot/commands/MailCommandTest.kt
+++ b/src/test/kotlin/at/fhooe/hagenberg/tutorbot/commands/MailCommandTest.kt
@@ -33,7 +33,7 @@ class MailCommandTest : CommandLineTest() {
         every { getReviewsSubDir() } returns "reviews"
     }
 
-    private val mailCommand = MailCommand(mailClient, saveFeedbackCommand, credentialStore, configHandler)
+    private val mailCommand = MailCommand(mailClient, credentialStore, configHandler)
 
     @get:Rule
     val fileSystem = FileSystemRule()
@@ -118,23 +118,6 @@ class MailCommandTest : CommandLineTest() {
         every { configHandler.getBaseDir() } returns File(fileSystem.directory, "nonexistant").absolutePath
 
         assertThrows<ProgramExitError> { mailCommand.execute() }
-    }
-
-    @Test
-    fun `Save feedback is executed when confirmed`() {
-        systemIn.provideLines("Subject", "Body", "Y", "Y")
-        mailCommand.execute()
-
-        verify { saveFeedbackCommand.execute() }
-        confirmVerified(saveFeedbackCommand)
-    }
-
-    @Test
-    fun `Save feedback is not executed when not confirmed`() {
-        systemIn.provideLines("Subject", "Body", "Y", "N")
-        mailCommand.execute()
-
-        confirmVerified(saveFeedbackCommand)
     }
 
     private fun verifyTestMail(){

--- a/src/test/kotlin/at/fhooe/hagenberg/tutorbot/commands/PlagiarismCommandTest.kt
+++ b/src/test/kotlin/at/fhooe/hagenberg/tutorbot/commands/PlagiarismCommandTest.kt
@@ -1,38 +1,56 @@
 package at.fhooe.hagenberg.tutorbot.commands
 
+import at.fhooe.hagenberg.tutorbot.components.ConfigHandler
 import at.fhooe.hagenberg.tutorbot.components.PlagiarismChecker
 import at.fhooe.hagenberg.tutorbot.testutil.CommandLineTest
 import at.fhooe.hagenberg.tutorbot.testutil.assertThrows
 import at.fhooe.hagenberg.tutorbot.testutil.rules.FileSystemRule
 import at.fhooe.hagenberg.tutorbot.util.ProgramExitError
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
+import java.nio.file.Path
 
 class PlagiarismCommandTest : CommandLineTest() {
+    private val submissionsLoc = "submissions"
+    private val exerciseLoc = "ue01"
+
     private val plagiarismChecker = mockk<PlagiarismChecker>()
 
-    private val plagiarismCommand = PlagiarismCommand(plagiarismChecker)
+    private val configHandler = mockk<ConfigHandler>() {
+        every { getExerciseSubDir() } returns exerciseLoc
+        every { getSubmissionsSubDir() } returns submissionsLoc
+    }
+
+    private val plagiarismCommand = PlagiarismCommand(plagiarismChecker, configHandler)
 
     @get:Rule
     val fileSystem = FileSystemRule()
 
+    private lateinit var submissionsDirFile: File
+    private lateinit var outputDirFile: File
+
+    @Before
+    fun setup() {
+        every { configHandler.getBaseDir() } returns fileSystem.directory.absolutePath.toString()
+        submissionsDirFile = Path.of(fileSystem.directory.absolutePath, exerciseLoc, submissionsLoc).toFile()
+        outputDirFile = Path.of(fileSystem.directory.absolutePath, exerciseLoc).toFile()
+    }
+
     @Test
     fun `Plagiarism checker is invoked correctly`() {
-       systemIn.provideLines(fileSystem.directory.absolutePath)
+        submissionsDirFile.mkdirs()
         plagiarismCommand.execute()
 
-        verify { plagiarismChecker.generatePlagiarismReport(fileSystem.directory) }
+        verify { plagiarismChecker.generatePlagiarismReport(submissionsDirFile, outputDirFile) }
     }
 
     @Test
     fun `Program exits with error if the submissions directory is not valid`() {
-        systemIn.provideLines(fileSystem.file.absolutePath)
-        assertThrows<ProgramExitError> { plagiarismCommand.execute() }
-
-        systemIn.provideLines(File(fileSystem.file, "nonexistant").absolutePath)
         assertThrows<ProgramExitError> { plagiarismCommand.execute() }
     }
 }

--- a/src/test/kotlin/at/fhooe/hagenberg/tutorbot/commands/SaveFeedbackCommandTest.kt
+++ b/src/test/kotlin/at/fhooe/hagenberg/tutorbot/commands/SaveFeedbackCommandTest.kt
@@ -1,8 +1,8 @@
 package at.fhooe.hagenberg.tutorbot.commands
 
 import at.fhooe.hagenberg.tutorbot.components.ConfigHandler
-import at.fhooe.hagenberg.tutorbot.components.FeedbackHelper
-import at.fhooe.hagenberg.tutorbot.components.FeedbackHelper.FeedbackCount
+import at.fhooe.hagenberg.tutorbot.components.FeedbackFileHelper
+import at.fhooe.hagenberg.tutorbot.domain.FeedbackCount
 import at.fhooe.hagenberg.tutorbot.testutil.assertThrows
 import at.fhooe.hagenberg.tutorbot.testutil.rules.FileSystemRule
 import at.fhooe.hagenberg.tutorbot.util.ProgramExitError
@@ -29,12 +29,12 @@ class SaveFeedbackCommandTest {
         every { getExerciseSubDir() } returns exerciseSubDir
         every { getReviewsSubDir() } returns reviewSubDir
     }
-    private val feedbackHelper = mockk<FeedbackHelper> {
+    private val feedbackFileHelper = mockk<FeedbackFileHelper> {
         every { readFeedbackCountFromReviews(any()) } returns reviewsInFolder
         every { writeFeedbackCountToCsv(any(), capture(feedbackCountWriteCapture)) } returns Unit
     }
 
-    private val saveFeedbackCommand = SaveFeedbackCommand(configHandler, feedbackHelper)
+    private val saveFeedbackCommand = SaveFeedbackCommand(configHandler, feedbackFileHelper)
 
     @get:Rule
     val fileSystem = FileSystemRule()
@@ -46,7 +46,7 @@ class SaveFeedbackCommandTest {
 
     @Test
     fun `When feedback dir empty, exits`() {
-        every { feedbackHelper.readFeedbackCountFromReviews(any()) } returns mapOf()
+        every { feedbackFileHelper.readFeedbackCountFromReviews(any()) } returns mapOf()
 
         assertThrows<ProgramExitError> {
             saveFeedbackCommand.execute()
@@ -55,7 +55,7 @@ class SaveFeedbackCommandTest {
 
     @Test
     fun `When read csv throws exception, exits`() {
-        every { feedbackHelper.readFeedbackCountFromCsv(any()) } throws IOException()
+        every { feedbackFileHelper.readFeedbackCountFromCsv(any()) } throws IOException()
 
         assertThrows<ProgramExitError> {
             saveFeedbackCommand.execute()
@@ -71,7 +71,7 @@ class SaveFeedbackCommandTest {
 
     @Test
     fun `When write throws exception, exits`() {
-        every { feedbackHelper.writeFeedbackCountToCsv(any(), capture(feedbackCountWriteCapture)) } throws IOException()
+        every { feedbackFileHelper.writeFeedbackCountToCsv(any(), capture(feedbackCountWriteCapture)) } throws IOException()
 
         assertThrows<ProgramExitError> {
             saveFeedbackCommand.execute()
@@ -84,7 +84,7 @@ class SaveFeedbackCommandTest {
             "S1" to FeedbackCount(0, 1),
             "S2" to FeedbackCount(0, 1)
         )
-        every { feedbackHelper.readFeedbackCountFromCsv(any()) } returns reviewsInCsv
+        every { feedbackFileHelper.readFeedbackCountFromCsv(any()) } returns reviewsInCsv
         val expectedFeedbackCount = mapOf(
             "S1" to FeedbackCount(1, 1),
             "S2" to FeedbackCount(0, 2)

--- a/src/test/kotlin/at/fhooe/hagenberg/tutorbot/commands/SubmissionsCommandTest.kt
+++ b/src/test/kotlin/at/fhooe/hagenberg/tutorbot/commands/SubmissionsCommandTest.kt
@@ -91,8 +91,9 @@ class SubmissionsCommandTest : CommandLineTest() {
     }
 
     private fun verifySubmissions(archiveExists: Boolean = false, submissionExists: Boolean = false) {
-        val submissionsLoc = Path.of(fileSystem.directory.absolutePath, exerciseLoc, submissionsLoc).toString()
-        verify { plagiarismChecker.generatePlagiarismReport(File(submissionsLoc)) }
+        val submissionsLoc = Path.of(fileSystem.directory.absolutePath, exerciseLoc, submissionsLoc).toFile()
+        val outputLoc = Path.of(fileSystem.directory.absolutePath, exerciseLoc).toFile()
+        verify { plagiarismChecker.generatePlagiarismReport(submissionsLoc, outputLoc) }
         assertEquals(archiveExists, File(submissionsLoc, "submission.zip").exists())
         assertEquals(submissionExists, File(submissionsLoc, "submission/submission.pdf").exists())
     }

--- a/src/test/kotlin/at/fhooe/hagenberg/tutorbot/components/FeedbackFileHelperTest.kt
+++ b/src/test/kotlin/at/fhooe/hagenberg/tutorbot/components/FeedbackFileHelperTest.kt
@@ -1,6 +1,6 @@
 package at.fhooe.hagenberg.tutorbot.components
 
-import at.fhooe.hagenberg.tutorbot.components.FeedbackHelper.FeedbackCount
+import at.fhooe.hagenberg.tutorbot.domain.FeedbackCount
 import at.fhooe.hagenberg.tutorbot.testutil.CommandLineTest
 import at.fhooe.hagenberg.tutorbot.testutil.assertThrows
 import at.fhooe.hagenberg.tutorbot.testutil.getResource
@@ -12,7 +12,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 
-class FeedbackHelperTest : CommandLineTest() {
+class FeedbackFileHelperTest : CommandLineTest() {
     private val lowerCaseStudentNumbers = listOf("s1", "s2", "s3", "s4", "s2210101010")
     private val studentFeedbackCount = listOf(
         "s1" to FeedbackCount(2, 0),
@@ -30,14 +30,14 @@ class FeedbackHelperTest : CommandLineTest() {
 
     private val reviewDir = getResource("pdfs")
 
-    private val feedbackHelper = FeedbackHelper()
+    private val feedbackFileHelper = FeedbackFileHelper()
 
     @get:Rule
     val fileSystem = FileSystemRule()
 
     @Test
     fun `Read reviews ignores invalid files`() {
-        val res = feedbackHelper.readAllReviewsFromDir(reviewDir)
+        val res = feedbackFileHelper.readAllReviewsFromDir(reviewDir)
         val invalidFile1 = "review.pdf"
         val invalidFile2 = "s1-invalid-file.pdf"
 
@@ -47,21 +47,21 @@ class FeedbackHelperTest : CommandLineTest() {
     @Test
     fun `Read reviews returns empty when dir empty`() {
         val emptyDir = File(fileSystem.directory.absolutePath)
-        val res = feedbackHelper.readAllReviewsFromDir(emptyDir)
+        val res = feedbackFileHelper.readAllReviewsFromDir(emptyDir)
 
         assert(res.isEmpty())
     }
 
     @Test
     fun `Read reviews includes right amount of files`() {
-        val res = feedbackHelper.readAllReviewsFromDir(reviewDir)
+        val res = feedbackFileHelper.readAllReviewsFromDir(reviewDir)
 
         assert(res.size == 4)
     }
 
     @Test
     fun `Read reviews gets student numbers lower case`() {
-        val res = feedbackHelper.readAllReviewsFromDir(reviewDir)
+        val res = feedbackFileHelper.readAllReviewsFromDir(reviewDir)
 
         assert(res.all { r -> r.revStudentNr in lowerCaseStudentNumbers && r.subStudentNr in lowerCaseStudentNumbers })
     }
@@ -69,21 +69,21 @@ class FeedbackHelperTest : CommandLineTest() {
     @Test
     fun `Read feedback returns empty when dir empty`() {
         val emptyDir = File(fileSystem.directory.absolutePath)
-        val res = feedbackHelper.readFeedbackCountFromReviews(emptyDir)
+        val res = feedbackFileHelper.readFeedbackCountFromReviews(emptyDir)
 
         assert(res.isEmpty())
     }
 
     @Test
     fun `Read feedback has key for every lower case student number`() {
-        val res = feedbackHelper.readFeedbackCountFromReviews(reviewDir)
+        val res = feedbackFileHelper.readFeedbackCountFromReviews(reviewDir)
 
         assert(res.all { f -> f.key in lowerCaseStudentNumbers })
     }
 
     @Test
     fun `Read feedback FeedbackCount has correct amount of submissions and reviews for each student`() {
-        val res = feedbackHelper.readFeedbackCountFromReviews(reviewDir)
+        val res = feedbackFileHelper.readFeedbackCountFromReviews(reviewDir)
 
         assert(studentFeedbackCount.all { s -> res[s.first] == s.second })
     }
@@ -93,7 +93,7 @@ class FeedbackHelperTest : CommandLineTest() {
         val file = fileSystem.directory.resolve("invalid-empty.csv")
 
         assertThrows<IOException> {
-            feedbackHelper.readFeedbackCountFromCsv(file)
+            feedbackFileHelper.readFeedbackCountFromCsv(file)
         }
     }
 
@@ -102,7 +102,7 @@ class FeedbackHelperTest : CommandLineTest() {
         val file = fileSystem.directory.resolve("notexists.csv")
 
         assertThrows<FileNotFoundException> {
-            feedbackHelper.readFeedbackCountFromCsv(file)
+            feedbackFileHelper.readFeedbackCountFromCsv(file)
         }
     }
 
@@ -111,7 +111,7 @@ class FeedbackHelperTest : CommandLineTest() {
         val file = getResource("csv/invalid-noheader.csv")
 
         assertThrows<IllegalArgumentException> {
-            feedbackHelper.readFeedbackCountFromCsv(file)
+            feedbackFileHelper.readFeedbackCountFromCsv(file)
         }
     }
 
@@ -120,14 +120,14 @@ class FeedbackHelperTest : CommandLineTest() {
         val file = getResource("csv/invalid-count.csv")
 
         assertThrows<NumberFormatException> {
-            feedbackHelper.readFeedbackCountFromCsv(file)
+            feedbackFileHelper.readFeedbackCountFromCsv(file)
         }
     }
 
     @Test
     fun `Read feedback from valid csv returns same values`(){
         val file = getResource("csv/valid.csv")
-        val res = feedbackHelper.readFeedbackCountFromCsv(file)
+        val res = feedbackFileHelper.readFeedbackCountFromCsv(file)
 
         assertEquals(validCsv, res)
     }
@@ -137,9 +137,9 @@ class FeedbackHelperTest : CommandLineTest() {
         val file = getResource("csv/valid.csv")
         val newFile = fileSystem.directory.resolve("newfile.csv")
 
-        val expected = feedbackHelper.readFeedbackCountFromCsv(file)
-        feedbackHelper.writeFeedbackCountToCsv(newFile, expected)
-        val res = feedbackHelper.readFeedbackCountFromCsv(newFile)
+        val expected = feedbackFileHelper.readFeedbackCountFromCsv(file)
+        feedbackFileHelper.writeFeedbackCountToCsv(newFile, expected)
+        val res = feedbackFileHelper.readFeedbackCountFromCsv(newFile)
 
         assertEquals(expected, res)
     }

--- a/src/test/kotlin/at/fhooe/hagenberg/tutorbot/components/PlagiarismCheckerTest.kt
+++ b/src/test/kotlin/at/fhooe/hagenberg/tutorbot/components/PlagiarismCheckerTest.kt
@@ -10,9 +10,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
+import java.nio.file.Path
 import java.nio.file.Paths
 
 class PlagiarismCheckerTest : CommandLineTest() {
+    private val submissionsLoc = "submissions"
+    private val exerciseLoc = "ue01"
+
     private val jplagWrapper = mockk<PlagiarismChecker.JplagWrapper>()
     private val configHandler = mockk<ConfigHandler>()
     private val args = slot<Array<String>>()
@@ -22,36 +26,50 @@ class PlagiarismCheckerTest : CommandLineTest() {
     @get:Rule
     val fileSystem = FileSystemRule()
 
+    private lateinit var submissionsDirFile: File
+    private lateinit var outputDirFile: File
+
     @Before
     fun setup() {
         every { jplagWrapper.run(capture(args)) } just Runs
+        submissionsDirFile = Path.of(fileSystem.directory.absolutePath, exerciseLoc, submissionsLoc).toFile()
+        submissionsDirFile.mkdirs()
+        outputDirFile = Path.of(fileSystem.directory.absolutePath, exerciseLoc).toFile()
     }
 
     @Test
     fun `JPlag is invoked correctly`() {
-        File(fileSystem.directory, "test.java").createNewFile()
-        plagiarismChecker.generatePlagiarismReport(fileSystem.directory)
+        File(submissionsDirFile, "test.java").createNewFile()
+        plagiarismChecker.generatePlagiarismReport(submissionsDirFile, outputDirFile)
 
-        val submissionPath = fileSystem.directory.absolutePath
-        val resultsPath = Paths.get(submissionPath, "plagiarism-report").toString()
-        val reportPath = Paths.get(resultsPath, "index.html").toString()
-        assertTrue(args.captured.joinToString(separator = " ").contains("-r $resultsPath -s $submissionPath"))
+        val resultsPath = Paths.get(outputDirFile.path, PlagiarismChecker.REPORT_FOLDER).toString()
+        val reportPath = Paths.get(resultsPath, PlagiarismChecker.INDEX_FILE).toString()
+        val logFilePath = Path.of(outputDirFile.path, PlagiarismChecker.REPORT_FOLDER, PlagiarismChecker.LOG_FILE)
+            .toString()
+
+        val capturedArgs = args.captured.joinToString(separator = " ")
+        // All arguments present, this test is not that useful
+        assertTrue(
+            capturedArgs.contains("-o") && capturedArgs.contains("-s") &&
+                    capturedArgs.contains("-vp") && capturedArgs.contains("-r") && capturedArgs.contains("-l") &&
+                    capturedArgs.contains(logFilePath) && capturedArgs.contains(resultsPath)
+        )
         assertTrue(systemOut.log.contains(reportPath))
     }
 
     @Test
     fun `Java language version from config is used if available`() {
         every { configHandler.getJavaLanguageLevel() } returns "java11"
-        File(fileSystem.directory, "test.java").createNewFile()
-        plagiarismChecker.generatePlagiarismReport(fileSystem.directory)
+        File(submissionsDirFile, "test.java").createNewFile()
+        plagiarismChecker.generatePlagiarismReport(submissionsDirFile, outputDirFile)
 
         assertTrue(args.captured.joinToString(separator = " ").contains("-l java11"))
     }
 
     @Test
     fun `C++ is detected correctly`() {
-        File(fileSystem.directory, "test.cpp").createNewFile()
-        plagiarismChecker.generatePlagiarismReport(fileSystem.directory)
+        File(submissionsDirFile, "test.cpp").createNewFile()
+        plagiarismChecker.generatePlagiarismReport(submissionsDirFile, outputDirFile)
 
         assertTrue(args.captured.joinToString(separator = " ").contains("-l c/c++"))
     }
@@ -59,7 +77,7 @@ class PlagiarismCheckerTest : CommandLineTest() {
     @Test
     fun `Program exits if language could not be detected`() {
         assertThrows<ProgramExitError> {
-            plagiarismChecker.generatePlagiarismReport(fileSystem.directory)
+            plagiarismChecker.generatePlagiarismReport(submissionsDirFile, outputDirFile)
         }
     }
 }


### PR DESCRIPTION
- Plagiarism folder now includes Log file `parser.log` which shows parsing errors and makes them more traceable. 
- Plagiarism folder moved to `exercise/plagiarism-report` instead of `exercise/submissions/plagiarism-report`.
- The feedback selection can now be saved instantly after `choose-feedback` was performed.
  - This makes working with multiple tutors easier as others can see the selection almost instantly.
- `ChooseFeedbackCommand` refactored, Logic split into own Class.
- Minor doc updates
- version bump v.1.4.1
